### PR TITLE
Renamed the community program labels

### DIFF
--- a/packages/esm-patient-hiv-art-app/package.json
+++ b/packages/esm-patient-hiv-art-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssemr/esm-patient-hiv-art-app",
-  "version": "5.5.6",
+  "version": "5.5.8",
   "license": "MPL-2.0",
   "description": "Patient dashboard microfrontend for the OpenMRS SPA",
   "browser": "dist/ssemr-esm-patient-hiv-art-app.js",

--- a/packages/esm-patient-hiv-art-app/src/home-dashboard/charts/AdultArtRegimen.tsx
+++ b/packages/esm-patient-hiv-art-app/src/home-dashboard/charts/AdultArtRegimen.tsx
@@ -29,7 +29,6 @@ const AdultARTRegimen = () => {
     curve: "curveMonotoneX",
     height: "400px",
   };
-  console.log("adult art", adultART);
 
   return (
     <div className={styles.chartContainer}>

--- a/packages/esm-patient-hiv-art-app/src/home-dashboard/charts/ChildArtRegimen.tsx
+++ b/packages/esm-patient-hiv-art-app/src/home-dashboard/charts/ChildArtRegimen.tsx
@@ -29,7 +29,6 @@ const ChildArtRegimen = () => {
     curve: "curveMonotoneX",
     height: "400px",
   };
-  console.log("child art regimen", childART);
 
   return (
     <div className={styles.chartContainer}>


### PR DESCRIPTION
Instead of **active** and **inactive** we use **under care** and **not under care**

@Michaelndula 